### PR TITLE
Remove func array_key_first

### DIFF
--- a/inc/functions.inc.php
+++ b/inc/functions.inc.php
@@ -27,19 +27,3 @@
  * Global functions
  */
 
-/**
- *
- */
-if (!function_exists('array_key_first')) {
-    /**
-     * @param array $arr
-     * @return int|string|null
-     */
-    function array_key_first(array $arr)
-    {
-        foreach ($arr as $key => $unused) {
-            return $key;
-        }
-        return NULL;
-    }
-}


### PR DESCRIPTION
Require PHP-Version is >= PHP 7.4 function array_key_first() is available as of php 7.3.0